### PR TITLE
[#29] local에서 h2 DB 활성화, redis profile 제거, EnableJpaAuditing 설정 추가

### DIFF
--- a/src/main/java/com/health/healther/HealtherApplication.java
+++ b/src/main/java/com/health/healther/HealtherApplication.java
@@ -2,12 +2,14 @@ package com.health.healther;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class HealtherApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(HealtherApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(HealtherApplication.class, args);
+	}
 
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,3 +19,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,6 @@ spring:
   profiles:
     group:
       "test": "test"
-      "local": "local, redis, oauth"
-      "dev": "dev, datasource, redis, oauth"
-      "prod": "prod, datasource, redis, oauth"
+      "local": "local, oauth"
+      "dev": "dev, datasource, oauth"
+      "prod": "prod, datasource, oauth"


### PR DESCRIPTION
## Issue
- #29 

## Description
1. local yml 파일에서
```
h2:
    console:
      enabled: true
```
설정이 누락되어 추가하였습니다.
2. JpaAuditing 어노테이션이 누락되어 추가하였습니다
3. 각 yml 파일에서 아직 설정하지 않은 redis를 group에서 임시로 제거하였습니다

## Todo
- [x] JpaAuditing 설정 누락되어있어 추가
- [x] local에서 h2 DB 활성화
- [x] yml에서 redis 설정 임시 제거

## ETC