### PR TITLE
[#37] Security Config 및 JwtAuthenticationFilter 추가

### DIFF
--- a/src/main/java/com/health/healther/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/health/healther/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package com.health.healther.config;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.health.healther.exception.member.MemberErrorCode;
+import com.health.healther.exception.member.SendErrorResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+		Object errorObject = request.getAttribute("MemberCustomException");
+		if (errorObject != null) {
+			sendError(response, MemberErrorCode.UNAUTHORIZED_USER);
+		}
+		sendError(response, MemberErrorCode.FORBIDDEN_USER);
+	}
+
+	private void sendError(HttpServletResponse response, MemberErrorCode errorCode) throws IOException {
+		response.setStatus(errorCode.getHttpStatus().value());
+		response.setContentType("application/json,charset=utf-8");
+		try (OutputStream os = response.getOutputStream()) {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.writeValue(os,
+				new SendErrorResponse(errorCode.getHttpStatus().value(), errorCode.name(), errorCode.getDescription()));
+			os.flush();
+		}
+	}
+}

--- a/src/main/java/com/health/healther/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/health/healther/config/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.health.healther.config;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.health.healther.exception.member.MemberCustomException;
+import com.health.healther.service.AuthService;
+import com.health.healther.util.UserAuthentication;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	public static final String TOKEN_HEADER = "Authorization";
+	public static final String TOKEN_PREFIX = "Bearer ";
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final AuthService authService;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			String token = resolveTokenFromRequest(request);
+			if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+				Long id = authService.findMemberByToken(token);
+				UserAuthentication authentication = new UserAuthentication(id);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		} catch (MemberCustomException e) {
+			request.setAttribute("MemberCustomException", e);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveTokenFromRequest(HttpServletRequest request) {
+		String token = request.getHeader(TOKEN_HEADER);
+		if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+			return token.substring(TOKEN_PREFIX.length());
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/health/healther/config/SecurityConfig.java
+++ b/src/main/java/com/health/healther/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 			.exceptionHandling()
 			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
 			.and()
-			.sessionManagement()//세션 정책 설정
+			.sessionManagement()
 			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/health/healther/config/SecurityConfig.java
+++ b/src/main/java/com/health/healther/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.health.healther.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return web -> web.ignoring()
+			.antMatchers(HttpMethod.GET, "/login/callback/**")
+			.antMatchers(HttpMethod.POST, "/login/oauth2/signUp")
+			.antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs");
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.cors()
+			.and()
+			.httpBasic().disable()
+			.formLogin().disable()
+			.csrf().disable()
+			.headers().frameOptions().disable()
+			.and()
+			.authorizeRequests()
+			.antMatchers("/login/callback/**", "/login/oauth2/signUp").permitAll()
+			.and()
+			.exceptionHandling()
+			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+			.and()
+			.sessionManagement()//세션 정책 설정
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+		return http.build();
+	}
+}

--- a/src/main/java/com/health/healther/controller/OauthController.java
+++ b/src/main/java/com/health/healther/controller/OauthController.java
@@ -2,6 +2,8 @@ package com.health.healther.controller;
 
 import java.net.URI;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +33,7 @@ public class OauthController {
 	}
 
 	@PostMapping("/login/oauth2/signUp")
-	public ResponseEntity<LoginResponse> signUp(@RequestParam String oauthId, @RequestBody SignUpForm form) {
+	public ResponseEntity<LoginResponse> signUp(@RequestParam String oauthId, @RequestBody @Valid SignUpForm form) {
 		return ResponseEntity.ok(oauthService.signUpAndCreateJwtAuth(oauthId, form));
 	}
 

--- a/src/main/java/com/health/healther/domain/model/Member.java
+++ b/src/main/java/com/health/healther/domain/model/Member.java
@@ -53,7 +53,7 @@ public class Member extends BaseEntity {
 	@Column(name = "LOGIN_TYPE")
 	private LoginType loginType;
 
-	public void updateMember(String name, String nickName, String phone) {
+	public void updateFromSignUpForm(String name, String nickName, String phone) {
 		this.name = name;
 		this.nickName = nickName;
 		this.phone = phone;

--- a/src/main/java/com/health/healther/exception/member/SendErrorResponse.java
+++ b/src/main/java/com/health/healther/exception/member/SendErrorResponse.java
@@ -1,0 +1,14 @@
+package com.health.healther.exception.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendErrorResponse {
+	private int status;
+	private String code;
+	private String message;
+}

--- a/src/main/java/com/health/healther/service/AuthService.java
+++ b/src/main/java/com/health/healther/service/AuthService.java
@@ -1,0 +1,35 @@
+package com.health.healther.service;
+
+import static com.health.healther.exception.member.MemberErrorCode.*;
+
+import org.springframework.stereotype.Service;
+
+import com.health.healther.config.JwtTokenProvider;
+import com.health.healther.domain.model.Member;
+import com.health.healther.exception.member.MemberCustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+	private final JwtTokenProvider jwtTokenProvider;
+	private final MemberService memberService;
+
+	public Long findMemberByToken(String accessToken) {
+		if (!accessToken.isEmpty()) {
+			accessTokenCheck(accessToken);
+		}
+		Long id = Long.parseLong(jwtTokenProvider.getPayload(accessToken));
+		Member member = memberService.findById(id);
+		return member.getId();
+	}
+
+	public void accessTokenCheck(String accessToken) {
+		if (!jwtTokenProvider.validateToken(accessToken)) {
+			throw new MemberCustomException(UNAUTHORIZED_ACCESS_TOKEN);
+		}
+	}
+}

--- a/src/main/java/com/health/healther/service/MemberService.java
+++ b/src/main/java/com/health/healther/service/MemberService.java
@@ -1,0 +1,27 @@
+package com.health.healther.service;
+
+import static com.health.healther.exception.member.MemberErrorCode.*;
+
+import org.springframework.stereotype.Service;
+
+import com.health.healther.domain.model.Member;
+import com.health.healther.domain.repository.MemberRepository;
+import com.health.healther.exception.member.MemberCustomException;
+import com.health.healther.util.SecurityUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+	private final MemberRepository memberRepository;
+
+	public Member findById(Long id) {
+		return memberRepository.findById(id).orElseThrow(() -> new MemberCustomException(NOT_FOUND_MEMBER));
+	}
+
+	public Member findUserFromToken() {
+		return memberRepository.findById(SecurityUtil.getCurrentUserId())
+			.orElseThrow(() -> new MemberCustomException(NOT_FOUND_MEMBER));
+	}
+}

--- a/src/main/java/com/health/healther/service/OauthService.java
+++ b/src/main/java/com/health/healther/service/OauthService.java
@@ -69,7 +69,7 @@ public class OauthService {
 	public LoginResponse signUpAndCreateJwtAuth(String oauthId, SignUpForm form) {
 		Member member = memberRepository.findByOauthId(oauthId)
 			.orElseThrow(() -> new MemberCustomException(NOT_FOUND_MEMBER));
-		member.updateMember(form.getName(), form.getNickName(), form.getPhone());
+		member.updateFromSignUpForm(form.getName(), form.getNickName(), form.getPhone());
 		String accessToken = jwtAuthenticationProvider.createAccessToken(String.valueOf(member.getId()));
 		String refreshToken = jwtAuthenticationProvider.createRefreshToken();
 		return LoginResponse.builder()

--- a/src/main/java/com/health/healther/util/SecurityUtil.java
+++ b/src/main/java/com/health/healther/util/SecurityUtil.java
@@ -1,0 +1,15 @@
+package com.health.healther.util;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor
+public class SecurityUtil {
+	public static Long getCurrentUserId() {
+		UserAuthentication authentication = (UserAuthentication)SecurityContextHolder.getContext().getAuthentication();
+		return authentication.getUserId();
+	}
+}

--- a/src/main/java/com/health/healther/util/UserAuthentication.java
+++ b/src/main/java/com/health/healther/util/UserAuthentication.java
@@ -1,0 +1,39 @@
+package com.health.healther.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class UserAuthentication extends AbstractAuthenticationToken {
+	private static final String USER = "USER";
+
+	private final Long userId;
+
+	public UserAuthentication(Long userId) {
+		super(authorities());
+		this.userId = userId;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return null;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return userId;
+	}
+
+	public Long getUserId() {
+		return userId;
+	}
+
+	private static List<GrantedAuthority> authorities() {
+		List<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(new SimpleGrantedAuthority(USER));
+		return authorities;
+	}
+}


### PR DESCRIPTION
## Issue

- #37

## Description

- JwtAuthenticationFilter 및 Security Config를 추가하였습니다.
- 단일 USER 권한을 부여하기 위해 UserAuthentication util을 추가하였습니다.
- 권한 여부를 validate 하기 위해 SecurityUtil과 AuthService, MemberService를 추가하였습니다.
- POSTMAN을 통한 회원가입 되는 것 확인하였습니다.

## Todo
- [x] JwtAuthenticationFilter 
- [x] SecurityConfig
- [x] UserAuthentication
- [x] SecurityUtil, AuthService, MemberService

## ETC
- POSTMAN 테스트 하는법 문의주시면 slack에 올리겠습니다.
- Merge 후 Jwt 토큰으로 유저 정보 가져오는 코드 시도해보겠습니다.
- 궁금하신점 언제든지 남겨주세요!