### PR TITLE
[#39] 회원정보 수정 API

### DIFF
--- a/src/main/java/com/health/healther/controller/MemberController.java
+++ b/src/main/java/com/health/healther/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.health.healther.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.health.healther.dto.member.MemberDto;
+import com.health.healther.dto.member.SignUpForm;
+import com.health.healther.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+	private final MemberService memberService;
+
+	@PutMapping("/users/{memberId}")
+	public ResponseEntity<MemberDto> updateMember(@PathVariable Long memberId, @RequestBody @Valid SignUpForm form) {
+		return ResponseEntity.ok(MemberDto.from(memberService.updateMember(memberId, form)));
+	}
+}

--- a/src/main/java/com/health/healther/dto/member/MemberDto.java
+++ b/src/main/java/com/health/healther/dto/member/MemberDto.java
@@ -1,0 +1,45 @@
+package com.health.healther.dto.member;
+
+import com.health.healther.constant.LoginType;
+import com.health.healther.constant.MemberStatus;
+import com.health.healther.domain.model.Member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberDto {
+	private Long id;
+
+	private String name;
+
+	private String nickName;
+
+	private String phone;
+
+	private MemberStatus memberStatus;
+
+	private String oauthId;
+
+	private LoginType loginType;
+
+	public static MemberDto from(Member member) {
+		return MemberDto.builder()
+			.id(member.getId())
+			.name(member.getName())
+			.nickName(member.getNickName())
+			.phone(member.getPhone())
+			.memberStatus(member.getMemberStatus())
+			.oauthId(member.getOauthId())
+			.loginType(member.getLoginType())
+			.build();
+	}
+}

--- a/src/main/java/com/health/healther/service/MemberService.java
+++ b/src/main/java/com/health/healther/service/MemberService.java
@@ -3,16 +3,16 @@ package com.health.healther.service;
 import static com.health.healther.exception.member.MemberErrorCode.*;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.health.healther.domain.model.Member;
 import com.health.healther.domain.repository.MemberRepository;
+import com.health.healther.dto.member.SignUpForm;
 import com.health.healther.exception.member.MemberCustomException;
 import com.health.healther.util.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -25,5 +25,15 @@ public class MemberService {
 	public Member findUserFromToken() {
 		return memberRepository.findById(SecurityUtil.getCurrentUserId())
 			.orElseThrow(() -> new MemberCustomException(NOT_FOUND_MEMBER));
+	}
+
+	@Transactional
+	public Member updateMember(Long memberId, SignUpForm form) {
+		Member member = findUserFromToken();
+		if (!member.getId().equals(memberId)) {
+			throw new MemberCustomException(NOT_FOUND_MEMBER);
+		}
+		member.updateFromSignUpForm(form.getName(), form.getNickName(), form.getPhone());
+		return member;
 	}
 }

--- a/src/main/java/com/health/healther/service/MemberService.java
+++ b/src/main/java/com/health/healther/service/MemberService.java
@@ -10,7 +10,9 @@ import com.health.healther.exception.member.MemberCustomException;
 import com.health.healther.util.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {


### PR DESCRIPTION
## Issue

- #39

## Description
- 회원정보 수정 API를 구현했습니다.

## Todo
- [x] MemberDto 구현
- [x] MemberController 구현
- [x] Jwt 값을 이용하여 로그인 된 회원과 회원 정보 수정의 id 일치여부

## ETC
- 궁금한 점 있으시면 질문 남겨주세요!