### PR TITLE
[#58] 회원 정보 조회 API

### DIFF
--- a/src/main/java/com/health/healther/controller/MemberController.java
+++ b/src/main/java/com/health/healther/controller/MemberController.java
@@ -3,12 +3,13 @@ package com.health.healther.controller;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.health.healther.dto.member.MemberDto;
+import com.health.healther.dto.member.MemberSearchResponse;
 import com.health.healther.dto.member.SignUpForm;
 import com.health.healther.service.MemberService;
 
@@ -22,7 +23,13 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@PutMapping("/users/{memberId}")
-	public ResponseEntity<MemberDto> updateMember(@PathVariable Long memberId, @RequestBody @Valid SignUpForm form) {
-		return ResponseEntity.ok(MemberDto.from(memberService.updateMember(memberId, form)));
+	public ResponseEntity<Void> updateMember(@PathVariable Long memberId, @RequestBody @Valid SignUpForm form) {
+		memberService.updateMember(memberId, form);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/user/{memberId}")
+	public ResponseEntity<MemberSearchResponse> searchMember(@PathVariable Long memberId) {
+		return ResponseEntity.ok(MemberSearchResponse.from(memberService.searchMember(memberId)));
 	}
 }

--- a/src/main/java/com/health/healther/controller/OauthController.java
+++ b/src/main/java/com/health/healther/controller/OauthController.java
@@ -41,7 +41,7 @@ public class OauthController {
 		if (response.getTokenType() == null) {
 			HttpHeaders headers = new HttpHeaders();
 			headers.setLocation(
-				URI.create("http://localhost:8080/login/oauth2/signUp?oauthId=" + response.getOauthId()));
+				URI.create("http://localhost:3000/login/oauth2/signUp?oauthId=" + response.getOauthId()));
 			return new ResponseEntity<>(response, headers, HttpStatus.MOVED_PERMANENTLY);
 		} else {
 			return ResponseEntity.ok(response);

--- a/src/main/java/com/health/healther/dto/member/LoginResponse.java
+++ b/src/main/java/com/health/healther/dto/member/LoginResponse.java
@@ -13,6 +13,8 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class LoginResponse {
+	private String name;
+
 	private String nickName;
 
 	private String oauthId;

--- a/src/main/java/com/health/healther/dto/member/MemberSearchResponse.java
+++ b/src/main/java/com/health/healther/dto/member/MemberSearchResponse.java
@@ -1,0 +1,31 @@
+package com.health.healther.dto.member;
+
+import com.health.healther.domain.model.Member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberSearchResponse {
+	private String name;
+
+	private String nickName;
+
+	private String phone;
+
+	public static MemberSearchResponse from(Member member) {
+		return MemberSearchResponse.builder()
+			.name(member.getName())
+			.nickName(member.getNickName())
+			.phone(member.getPhone())
+			.build();
+	}
+}

--- a/src/main/java/com/health/healther/dto/member/userInfo/GoogleUserInfo.java
+++ b/src/main/java/com/health/healther/dto/member/userInfo/GoogleUserInfo.java
@@ -1,0 +1,26 @@
+package com.health.healther.dto.member.userInfo;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+	private final Map<String, Object> attributes;
+
+	public GoogleUserInfo(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	@Override
+	public String getProviderId() {
+		return String.valueOf(attributes.get("sub"));
+	}
+
+	@Override
+	public String getProvider() {
+		return "google";
+	}
+
+	public String getName() {
+		return String.valueOf(attributes.get("name"));
+	}
+}

--- a/src/main/java/com/health/healther/service/MemberService.java
+++ b/src/main/java/com/health/healther/service/MemberService.java
@@ -27,13 +27,20 @@ public class MemberService {
 			.orElseThrow(() -> new MemberCustomException(NOT_FOUND_MEMBER));
 	}
 
+	public Member searchMember(Long memberId) {
+		Member member = findUserFromToken();
+		if (!member.getId().equals(memberId)) {
+			throw new MemberCustomException(NOT_FOUND_MEMBER);
+		}
+		return member;
+	}
+
 	@Transactional
-	public Member updateMember(Long memberId, SignUpForm form) {
+	public void updateMember(Long memberId, SignUpForm form) {
 		Member member = findUserFromToken();
 		if (!member.getId().equals(memberId)) {
 			throw new MemberCustomException(NOT_FOUND_MEMBER);
 		}
 		member.updateFromSignUpForm(form.getName(), form.getNickName(), form.getPhone());
-		return member;
 	}
 }

--- a/src/main/java/com/health/healther/service/OauthService.java
+++ b/src/main/java/com/health/healther/service/OauthService.java
@@ -120,11 +120,13 @@ public class OauthService {
 		Map<String, Object> attributes = getUserAttribute(provider, tokenResponse);
 		OAuth2UserInfo oAuth2UserInfo;
 		String oauthNickName = null;
+		String oauthName = null;
 		if (providerName.equals("kakao")) {
 			oAuth2UserInfo = new KakaoUserInfo(attributes);
 			oauthNickName = ((KakaoUserInfo)oAuth2UserInfo).getNickName();
 		} else if (providerName.equals("google")) {
 			oAuth2UserInfo = new GoogleUserInfo(attributes);
+			oauthName = ((GoogleUserInfo)oAuth2UserInfo).getName();
 		} else {
 			log.info("잘못된 접근입니다.");
 			throw new MemberCustomException(INVALID_ACCESS);
@@ -134,6 +136,7 @@ public class OauthService {
 		Optional<Member> optionalMember = memberRepository.findByOauthId(oauthProviderId);
 		if (optionalMember.isEmpty()) {
 			Member member = Member.builder()
+				.name(oauthName)
 				.nickName(oauthNickName)
 				.memberStatus(NEED_DATA)
 				.loginType(getloginType(oauthProvider))

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -7,10 +7,16 @@ spring:
     oauth2:
       client:
         registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: http://${REDIRECT_HOST:localhost}:${REDIRECT_PORT:3000}/login/callback/google
+            scope: profile
+            client-name: google
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: http://${REDIRECT_HOST:localhost}:${REDIRECT_PORT:3000}/login/oauth2/code/kakao
+            redirect-uri: http://${REDIRECT_HOST:localhost}:${REDIRECT_PORT:3000}/login/callback/kakao
             client-authentication-method: POST
             authorization-grant-type: authorization_code
             scope:


### PR DESCRIPTION
## Issue

- #58 

## Description
- 회원 정보 수정 전에 회원 정보를 조회할 API 필요성을 느껴 만들었습니다.

## ETC
- Jwt 토큰으로부터 member 정보 받아올 때 참고 하시길 바랍니다.
1. MemberService 주입 받은 후 `Member member = memberService.findUserFromToken();` 하시면 됩니다.
2. 꼭 memberId 를 입력 받은 후 아래 로직이 들어가야 합니다.
```
if (!member.getId().equals(memberId)) {
    throw new MemberCustomException(NOT_FOUND_MEMBER);
}
```
3. Jwt에서 member 정보 조회 로직을 Util로 하는게 좋을지 고민중인데 의견 부탁드립니다..! 