### PR TITLE
[#87] 쿠폰 조회 리팩토링

### DIFF
--- a/src/main/java/com/health/healther/controller/CouponController.java
+++ b/src/main/java/com/health/healther/controller/CouponController.java
@@ -48,7 +48,7 @@ public class CouponController {
 	public ResponseEntity<List<CouponReservationListResponseDto>> getCoupon(
 		@PathVariable("spaceId") Long spaceId
 	) {
-		return ResponseEntity.ok(couponService.getCoupon(spaceId)); //.body(couponService.getCoupon(spaceId));
+		return ResponseEntity.ok(couponService.getCoupon(spaceId));
 	}
 
 	@PutMapping("/{couponId}")

--- a/src/main/java/com/health/healther/controller/CouponController.java
+++ b/src/main/java/com/health/healther/controller/CouponController.java
@@ -1,6 +1,7 @@
 package com.health.healther.controller;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ public class CouponController {
 
 	@PostMapping
 	public ResponseEntity addCoupon(
-			@RequestBody @Valid CouponCreateRequestDto createDto
+		@RequestBody @Valid CouponCreateRequestDto createDto
 	) {
 		couponService.addCoupon(createDto);
 		return ResponseEntity.ok().build();
@@ -35,7 +36,7 @@ public class CouponController {
 
 	@DeleteMapping("/{couponId}")
 	public ResponseEntity deleteCoupon(
-			@PathVariable("couponId") Long couponId
+		@PathVariable("couponId") Long couponId
 	) {
 		couponService.deleteCoupon(couponId);
 		return new ResponseEntity<>(HttpStatus.OK);
@@ -43,14 +44,15 @@ public class CouponController {
 
 	@GetMapping("/{spaceId}")
 	public ResponseEntity getCoupon(
-			@PathVariable("spaceId") Long spaceId
+		@PathVariable("spaceId") Long spaceId,
+		@RequestBody @NotNull Long memberId
 	) {
-		return ResponseEntity.ok().body(couponService.getCoupon(spaceId));
+		return ResponseEntity.ok().body(couponService.getCoupon(spaceId, memberId));
 	}
 
 	@PutMapping("/{couponId}")
 	public ResponseEntity updateCoupon(
-			@PathVariable("couponId") Long couponId,
+		@PathVariable("couponId") Long couponId,
 		@RequestBody @Valid CouponUpdateRequestDto couponUpdateRequestDto
 	) {
 		couponService.updateCoupon(couponId, couponUpdateRequestDto);

--- a/src/main/java/com/health/healther/controller/CouponController.java
+++ b/src/main/java/com/health/healther/controller/CouponController.java
@@ -1,7 +1,6 @@
 package com.health.healther.controller;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,10 +43,9 @@ public class CouponController {
 
 	@GetMapping("/{spaceId}")
 	public ResponseEntity getCoupon(
-		@PathVariable("spaceId") Long spaceId,
-		@RequestBody @NotNull Long memberId
+		@PathVariable("spaceId") Long spaceId
 	) {
-		return ResponseEntity.ok().body(couponService.getCoupon(spaceId, memberId));
+		return ResponseEntity.ok().body(couponService.getCoupon(spaceId));
 	}
 
 	@PutMapping("/{couponId}")

--- a/src/main/java/com/health/healther/controller/CouponController.java
+++ b/src/main/java/com/health/healther/controller/CouponController.java
@@ -1,5 +1,7 @@
 package com.health.healther.controller;
 
+import java.util.List;
+
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.health.healther.dto.coupon.CouponCreateRequestDto;
+import com.health.healther.dto.coupon.CouponReservationListResponseDto;
 import com.health.healther.dto.coupon.CouponUpdateRequestDto;
 import com.health.healther.service.CouponService;
 
@@ -42,10 +45,10 @@ public class CouponController {
 	}
 
 	@GetMapping("/{spaceId}")
-	public ResponseEntity getCoupon(
+	public ResponseEntity<List<CouponReservationListResponseDto>> getCoupon(
 		@PathVariable("spaceId") Long spaceId
 	) {
-		return ResponseEntity.ok().body(couponService.getCoupon(spaceId));
+		return ResponseEntity.ok(couponService.getCoupon(spaceId)); //.body(couponService.getCoupon(spaceId));
 	}
 
 	@PutMapping("/{couponId}")

--- a/src/main/java/com/health/healther/domain/repository/CouponRepository.java
+++ b/src/main/java/com/health/healther/domain/repository/CouponRepository.java
@@ -1,14 +1,14 @@
 package com.health.healther.domain.repository;
 
 import java.time.LocalDate;
-import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.health.healther.domain.model.Coupon;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
-	Optional<Coupon> findBySpace_IdAndMember_IdAndExpiredDateIsAfterAndOpenDateIsBeforeAndIsUsed(
+	List<Coupon> findBySpace_IdAndMember_IdAndExpiredDateIsAfterAndOpenDateIsBeforeAndIsUsed(
 		Long spaceId, Long memberId, LocalDate expiredNow, LocalDate openNow, boolean isUsed
 	);
 }

--- a/src/main/java/com/health/healther/domain/repository/CouponRepository.java
+++ b/src/main/java/com/health/healther/domain/repository/CouponRepository.java
@@ -1,7 +1,6 @@
 package com.health.healther.domain.repository;
 
 import java.time.LocalDate;
-
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.health.healther.domain.model.Coupon;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
-	Optional<Coupon> findBySpace_IdAndExpiredDateIsAfterAndIsUsed(Long spaceId, LocalDate now, boolean isUsed);
+	Optional<Coupon> findBySpace_IdAndMember_IdAndExpiredDateIsAfterAndOpenDateIsBeforeAndIsUsed(
+		Long spaceId, Long memberId, LocalDate expiredNow, LocalDate openNow, boolean isUsed
+	);
 }

--- a/src/main/java/com/health/healther/dto/coupon/CouponReservationListResponseDto.java
+++ b/src/main/java/com/health/healther/dto/coupon/CouponReservationListResponseDto.java
@@ -2,6 +2,8 @@ package com.health.healther.dto.coupon;
 
 import java.time.LocalDate;
 
+import com.health.healther.domain.model.Coupon;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +16,7 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class CouponReservationResponseDto {
+public class CouponReservationListResponseDto {
 	private Long couponId;
 
 	private int discountAmount;
@@ -24,4 +26,14 @@ public class CouponReservationResponseDto {
 	private String couponNumber;
 
 	private boolean isUsed;
+
+	public static CouponReservationListResponseDto from(Coupon coupon) {
+		return CouponReservationListResponseDto.builder()
+			.couponId(coupon.getId())
+			.discountAmount(coupon.getDiscountAmount())
+			.expiredDate(coupon.getExpiredDate())
+			.couponNumber(coupon.getCouponNumber())
+			.isUsed(coupon.isUsed())
+			.build();
+	}
 }

--- a/src/main/java/com/health/healther/dto/coupon/CouponReservationResponseDto.java
+++ b/src/main/java/com/health/healther/dto/coupon/CouponReservationResponseDto.java
@@ -14,20 +14,14 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class CouponResponseDto {
+public class CouponReservationResponseDto {
 	private Long couponId;
 
-	private String memberName;
-
 	private int discountAmount;
-
-	private LocalDate openDate;
 
 	private LocalDate expiredDate;
 
 	private String couponNumber;
-
-	private int amount;
 
 	private boolean isUsed;
 }

--- a/src/main/java/com/health/healther/service/CouponService.java
+++ b/src/main/java/com/health/healther/service/CouponService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.health.healther.domain.model.Coupon;
+import com.health.healther.domain.model.Member;
 import com.health.healther.domain.model.Space;
 import com.health.healther.domain.repository.CouponRepository;
 import com.health.healther.domain.repository.SpaceRepository;
@@ -26,6 +27,8 @@ public class CouponService {
 	private final CouponRepository couponRepository;
 
 	private final SpaceRepository spaceRepository;
+
+	private final MemberService memberService;
 
 	public void addCoupon(CouponCreateRequestDto createDto) {
 
@@ -56,14 +59,15 @@ public class CouponService {
 	}
 
 	@Transactional(readOnly = true)
-	public CouponReservationResponseDto getCoupon(Long spaceId, Long memberId) {
+	public CouponReservationResponseDto getCoupon(Long spaceId) {
+		Member member = memberService.findUserFromToken();
 
 		LocalDate expiredNow = LocalDate.now().minusDays(1);
 		LocalDate openNow = LocalDate.now().plusDays(1);
 
 		Optional<Coupon> optionalCoupon = couponRepository
 			.findBySpace_IdAndMember_IdAndExpiredDateIsAfterAndOpenDateIsBeforeAndIsUsed(
-				spaceId, memberId, expiredNow, openNow, false
+				spaceId, member.getId(), expiredNow, openNow, false
 			);
 
 		if (!optionalCoupon.isPresent()) {

--- a/src/main/java/com/health/healther/service/CouponService.java
+++ b/src/main/java/com/health/healther/service/CouponService.java
@@ -62,12 +62,12 @@ public class CouponService {
 	public CouponReservationResponseDto getCoupon(Long spaceId) {
 		Member member = memberService.findUserFromToken();
 
-		LocalDate expiredNow = LocalDate.now().minusDays(1);
-		LocalDate openNow = LocalDate.now().plusDays(1);
+		LocalDate expiredDt = LocalDate.now().minusDays(1);
+		LocalDate openDt = LocalDate.now().plusDays(1);
 
 		Optional<Coupon> optionalCoupon = couponRepository
 			.findBySpace_IdAndMember_IdAndExpiredDateIsAfterAndOpenDateIsBeforeAndIsUsed(
-				spaceId, member.getId(), expiredNow, openNow, false
+				spaceId, member.getId(), expiredDt, openDt, false
 			);
 
 		if (!optionalCoupon.isPresent()) {


### PR DESCRIPTION
## Issue

- #87 

## Description

- 쿠폰 조회 API를 예약 시 해당 회원이 사용가능한 쿠폰 리스트를 조회하는 API로 리팩토링 하였습니다
- ~~ResponseBody로 memberId를 추가하였습니다~~
- ~~`CouponResponseDto`명을 `CouponReservationResponseDto`로 변경하였습니다~~ 
`CouponReservationListResponseDto`로 변경하였습니다!
- `CouponReservationListResponseDto`에 필요한 정보만을 담았습니다


## Todo

## ETC

- ~~CouponService에서 오픈날짜와 만료날짜 사이의 값을 가져오기 위해 `openNow`, `expiredNow`라는 변수를 생성하였는데 좀 더 직관적인 변수명이 있을까요?~~
- 현재 develop브랜치에 리팩토링 전에 사용되었던 `CouponCustomException`, `CouponErrorCode`가 존재하고 있습니다! 
삭제 파일을 커밋해주지 않아 생긴 문제 같습니다. 이후 브랜치에서 전체적인 코드 리팩토링을 다룰 예정이라 해당 브랜치에서 삭제파일을 커밋하도록 하겠습니다..!
- 또한 동호님이 말씀 주셨던 dto 리팩토링과 공백 제거같은 코드 리팩토링도 이후에 함께 다루도록 하겠습니다
- 질문사항 또는 수정사항이 있다면 언제든 comment남겨주시면 감사하겠습니다 :)