### PR TITLE
[#110] refreshToken을 추가한 로그인 기능 리팩토링

### DIFF
--- a/src/main/java/com/health/healther/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/health/healther/config/JwtAuthenticationFilter.java
@@ -24,8 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-	public static final String TOKEN_HEADER = "Authorization";
-	public static final String TOKEN_PREFIX = "Bearer ";
+	public static final String AUTHORIZATION = "Authorization";
+	public static String BEARER_TYPE = "Bearer";
 	private final JwtTokenProvider jwtTokenProvider;
 	private final AuthService authService;
 
@@ -47,9 +47,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	private String resolveTokenFromRequest(HttpServletRequest request) {
-		String token = request.getHeader(TOKEN_HEADER);
-		if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
-			return token.substring(TOKEN_PREFIX.length());
+		String token = request.getHeader(AUTHORIZATION);
+		if (!ObjectUtils.isEmpty(token) && token.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+			return token.substring(BEARER_TYPE.length()).trim();
 		}
 		return null;
 	}

--- a/src/main/java/com/health/healther/config/JwtTokenProvider.java
+++ b/src/main/java/com/health/healther/config/JwtTokenProvider.java
@@ -1,12 +1,12 @@
 package com.health.healther.config;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.Random;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.health.healther.dto.member.Token;
 import com.health.healther.exception.member.UnauthorizedMemberException;
 
 import io.jsonwebtoken.Claims;
@@ -30,15 +30,14 @@ public class JwtTokenProvider {
 	@Value("${jwt.token.secret-key}")
 	private String secretKey;
 
-	public String createAccessToken(String payload) {
-		return createToken(payload, accessTokenValidityInMilliseconds);
+	public Token createAccessToken(String payload) {
+		String token = createToken(payload, accessTokenValidityInMilliseconds);
+		return new Token(token, accessTokenValidityInMilliseconds);
 	}
 
-	public String createRefreshToken() {
-		byte[] array = new byte[7];
-		new Random().nextBytes(array);
-		String generatedString = new String(array, StandardCharsets.UTF_8);
-		return createToken(generatedString, refreshTokenValidityInMilliseconds);
+	public Token createRefreshToken() {
+		String token = createToken(UUID.randomUUID().toString(), refreshTokenValidityInMilliseconds);
+		return new Token(token, refreshTokenValidityInMilliseconds);
 	}
 
 	private String createToken(String payload, long expiredLength) {

--- a/src/main/java/com/health/healther/config/RedisConfig.java
+++ b/src/main/java/com/health/healther/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.health.healther.config;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+	private final RedisProperties redisProperties;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/health/healther/config/SecurityConfig.java
+++ b/src/main/java/com/health/healther/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.health.healther.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -28,6 +30,12 @@ public class SecurityConfig {
 	}
 
 	@Bean
+	public AuthenticationManager authenticationManager(
+		AuthenticationConfiguration authenticationConfiguration) throws Exception {
+		return authenticationConfiguration.getAuthenticationManager();
+	}
+
+	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 			.cors()
@@ -48,6 +56,7 @@ public class SecurityConfig {
 			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
 		return http.build();
 	}
 }

--- a/src/main/java/com/health/healther/config/SecurityConfig.java
+++ b/src/main/java/com/health/healther/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
 		return web -> web.ignoring()
 			.antMatchers(HttpMethod.GET, "/members/login/callback/**")
 			.antMatchers(HttpMethod.POST, "/members/signUp")
+			.antMatchers(HttpMethod.POST, "/members/reissue")
 			.antMatchers("/h2-console/**");
 	}
 

--- a/src/main/java/com/health/healther/dto/member/AccessTokenResponseDto.java
+++ b/src/main/java/com/health/healther/dto/member/AccessTokenResponseDto.java
@@ -1,6 +1,5 @@
 package com.health.healther.dto.member;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,16 +7,12 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@Builder
 @ToString
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@NoArgsConstructor
 @AllArgsConstructor
-public class MemberLoginResponseDto {
-	private String tokenType;
-
+public class AccessTokenResponseDto {
 	private String accessToken;
 
 	private Long accessTokenExpiredTime;
-
-	private String refreshToken;
 }

--- a/src/main/java/com/health/healther/dto/member/RefreshTokenRequestDto.java
+++ b/src/main/java/com/health/healther/dto/member/RefreshTokenRequestDto.java
@@ -1,7 +1,6 @@
 package com.health.healther.dto.member;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +12,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RefreshTokenRequestDto {
-	@NotNull
 	@NotBlank
 	private String refreshToken;
 }

--- a/src/main/java/com/health/healther/dto/member/RefreshTokenRequestDto.java
+++ b/src/main/java/com/health/healther/dto/member/RefreshTokenRequestDto.java
@@ -1,0 +1,19 @@
+package com.health.healther.dto.member;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenRequestDto {
+	@NotNull
+	@NotBlank
+	private String refreshToken;
+}

--- a/src/main/java/com/health/healther/dto/member/Token.java
+++ b/src/main/java/com/health/healther/dto/member/Token.java
@@ -1,0 +1,13 @@
+package com.health.healther.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Token {
+	private String value;
+	private long expiredTime;
+}

--- a/src/main/java/com/health/healther/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/com/health/healther/exception/member/MemberExceptionHandler.java
@@ -44,4 +44,20 @@ public class MemberExceptionHandler {
 		return ResponseEntity.badRequest()
 			.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
 	}
+
+	@ExceptionHandler(UnauthorizedAccessTokenException.class)
+	public ResponseEntity<ErrorMessage> UnauthorizedAccessTokenException(
+		UnauthorizedAccessTokenException exception
+	) {
+		return ResponseEntity.badRequest()
+			.body(ErrorMessage.of(exception, HttpStatus.UNAUTHORIZED));
+	}
+
+	@ExceptionHandler(UnauthorizedRefreshTokenException.class)
+	public ResponseEntity<ErrorMessage> UnauthorizedRefreshTokenException(
+		UnauthorizedRefreshTokenException exception
+	) {
+		return ResponseEntity.badRequest()
+			.body(ErrorMessage.of(exception, HttpStatus.UNAUTHORIZED));
+	}
 }

--- a/src/main/java/com/health/healther/exception/member/UnauthorizedAccessTokenException.java
+++ b/src/main/java/com/health/healther/exception/member/UnauthorizedAccessTokenException.java
@@ -1,0 +1,7 @@
+package com.health.healther.exception.member;
+
+public class UnauthorizedAccessTokenException extends RuntimeException {
+	public UnauthorizedAccessTokenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/health/healther/exception/member/UnauthorizedRefreshTokenException.java
+++ b/src/main/java/com/health/healther/exception/member/UnauthorizedRefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.health.healther.exception.member;
+
+public class UnauthorizedRefreshTokenException extends RuntimeException {
+	public UnauthorizedRefreshTokenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/health/healther/service/AuthService.java
+++ b/src/main/java/com/health/healther/service/AuthService.java
@@ -1,10 +1,17 @@
 package com.health.healther.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.health.healther.config.JwtTokenProvider;
 import com.health.healther.domain.model.Member;
+import com.health.healther.dto.member.AccessTokenResponseDto;
+import com.health.healther.dto.member.RefreshTokenRequestDto;
+import com.health.healther.dto.member.Token;
 import com.health.healther.exception.member.InvalidTokenException;
+import com.health.healther.exception.member.UnauthorizedAccessTokenException;
+import com.health.healther.exception.member.UnauthorizedRefreshTokenException;
+import com.health.healther.util.RedisUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,19 +22,51 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final MemberService memberService;
+	private final RedisUtil redisUtil;
 
 	public Long findMemberByToken(String accessToken) {
 		if (!accessToken.isEmpty()) {
-			accessTokenCheck(accessToken);
+			validateAccessToken(accessToken);
 		}
 		Long id = Long.parseLong(jwtTokenProvider.getPayload(accessToken));
 		Member member = memberService.findById(id);
 		return member.getId();
 	}
 
-	public void accessTokenCheck(String accessToken) {
-		if (!jwtTokenProvider.validateToken(accessToken)) {
+	public AccessTokenResponseDto accessTokenByRefreshToken(
+		String accessToken,
+		RefreshTokenRequestDto refreshTokenRequest
+	) {
+		validateRefreshToken(refreshTokenRequest);
+		String id = jwtTokenProvider.getPayload(accessToken);
+		String data = redisUtil.getData(id);
+		if (!data.equals(refreshTokenRequest.getRefreshToken())) {
 			throw new InvalidTokenException("유효하지 않는 액세스 토큰입니다.");
+		}
+		Token newAccessToken = jwtTokenProvider.createAccessToken(id);
+		return AccessTokenResponseDto
+			.builder()
+			.accessToken(newAccessToken.getValue())
+			.accessTokenExpiredTime(newAccessToken.getExpiredTime())
+			.build();
+	}
+
+	@Transactional
+	public String logout(String accessToken) {
+		String id = jwtTokenProvider.getPayload(accessToken);
+		redisUtil.deleteData(id);
+		return "로그아웃이 완료 되었습니다.";
+	}
+
+	private void validateAccessToken(String accessToken) {
+		if (!jwtTokenProvider.validateToken(accessToken)) {
+			throw new UnauthorizedAccessTokenException("인가되지 않은 access 토큰입니다.");
+		}
+	}
+
+	private void validateRefreshToken(RefreshTokenRequestDto refreshTokenRequest) {
+		if (!jwtTokenProvider.validateToken(refreshTokenRequest.getRefreshToken())) {
+			throw new UnauthorizedRefreshTokenException("인가되지 않은 refresh 토큰입니다.");
 		}
 	}
 }

--- a/src/main/java/com/health/healther/service/MemberService.java
+++ b/src/main/java/com/health/healther/service/MemberService.java
@@ -8,6 +8,7 @@ import com.health.healther.domain.repository.MemberRepository;
 import com.health.healther.dto.member.MemberUpdateRequestDto;
 import com.health.healther.exception.member.NotFoundMemberException;
 import com.health.healther.exception.member.NotMatchMemberException;
+import com.health.healther.util.RedisUtil;
 import com.health.healther.util.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberService {
 	private final MemberRepository memberRepository;
+	private final RedisUtil redisUtil;
 
 	public Member findById(Long id) {
 		return memberRepository.findById(id)
@@ -40,6 +42,7 @@ public class MemberService {
 	@Transactional
 	public void deleteMember() {
 		Member member = findUserFromToken();
+		redisUtil.deleteData(String.valueOf(member.getId()));
 		memberRepository.delete(member);
 	}
 }

--- a/src/main/java/com/health/healther/util/AuthTransformUtil.java
+++ b/src/main/java/com/health/healther/util/AuthTransformUtil.java
@@ -1,0 +1,24 @@
+package com.health.healther.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthTransformUtil {
+	public static final String AUTHORIZATION = "Authorization";
+	public static String BEARER_TYPE = "Bearer";
+
+	public static String resolveTokenFromRequest(HttpServletRequest request) {
+		String token = request.getHeader(AUTHORIZATION);
+		if (!ObjectUtils.isEmpty(token) && token.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+			return token.substring(BEARER_TYPE.length()).trim();
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/health/healther/util/RedisUtil.java
+++ b/src/main/java/com/health/healther/util/RedisUtil.java
@@ -1,0 +1,37 @@
+package com.health.healther.util;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+	private final StringRedisTemplate stringRedisTemplate;
+
+	public String getData(String key) {
+		ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+		return valueOperations.get(key);
+	}
+
+	public void setData(String key, String value) {
+		ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+		valueOperations.set(key, value);
+	}
+
+	public void setDataExpire(String key, String value, long duration) {
+		ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+		Duration expireDuration = Duration.ofSeconds(duration);
+		valueOperations.set(key, value, expireDuration);
+	}
+
+	public void deleteData(String key) {
+		stringRedisTemplate.delete(key);
+	}
+}


### PR DESCRIPTION
## Issue

- #110 

## Description
- accessToken 만료시 Redis 내의 refreshToken을 이용하여 새로운 accessToken을 반환하게 하였습니다.
- 회원가입 / 로그인 판별시 provider의 대소문자 구분을 없앴습니다.
- 반환값에 accessToken 만료시간을 기입하는게 좋다는 [게시글](https://han-um.tistory.com/17)을 보고 반영하였습니다.

## ETC
- build.gradle 내 redis 설정은 게시글마다 상이하여 추가하지 않았습니다. (spring.redis.lettuce.pool 관련설정)
- POSTMAN을 통해 작동하는 거 확인하였고 최신화 하였습니다.
- 코드량의 증가로 회원가입/로그인 시 상당한 시간이 걸릴거라 생각합니다 -> 추후 개선 방향 연구해볼게요
- 코드량이 급하게 하다보니 상당량입니다. 양해 부탁드립니다😭 