### PR TITLE
[#125] 예약 취소 시 쿠폰 사용 취소 로직 생성

### DIFF
--- a/src/main/java/com/health/healther/exception/coupon/CouponExceptionHandler.java
+++ b/src/main/java/com/health/healther/exception/coupon/CouponExceptionHandler.java
@@ -39,11 +39,4 @@ public class CouponExceptionHandler {
 			.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
 	}
 
-	@ExceptionHandler(NotExistCouponInReservationException.class)
-	public ResponseEntity<ErrorMessage> NotExistCouponInReservationException(
-		NotExistCouponInReservationException exception
-	) {
-		return ResponseEntity.badRequest()
-			.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
-	}
 }

--- a/src/main/java/com/health/healther/exception/coupon/CouponExceptionHandler.java
+++ b/src/main/java/com/health/healther/exception/coupon/CouponExceptionHandler.java
@@ -30,4 +30,20 @@ public class CouponExceptionHandler {
 		return ResponseEntity.badRequest()
 			.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
 	}
+
+	@ExceptionHandler(NotUsedCouponException.class)
+	public ResponseEntity<ErrorMessage> NotUseCouponException(
+		NotUsedCouponException exception
+	) {
+		return ResponseEntity.badRequest()
+			.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
+
+	@ExceptionHandler(NotExistCouponInReservationException.class)
+	public ResponseEntity<ErrorMessage> NotExistCouponInReservationException(
+		NotExistCouponInReservationException exception
+	) {
+		return ResponseEntity.badRequest()
+			.body(ErrorMessage.of(exception, HttpStatus.BAD_REQUEST));
+	}
 }

--- a/src/main/java/com/health/healther/exception/coupon/NotExistCouponInReservationException.java
+++ b/src/main/java/com/health/healther/exception/coupon/NotExistCouponInReservationException.java
@@ -1,0 +1,7 @@
+package com.health.healther.exception.coupon;
+
+public class NotExistCouponInReservationException extends RuntimeException {
+	public NotExistCouponInReservationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/health/healther/exception/coupon/NotExistCouponInReservationException.java
+++ b/src/main/java/com/health/healther/exception/coupon/NotExistCouponInReservationException.java
@@ -1,7 +1,0 @@
-package com.health.healther.exception.coupon;
-
-public class NotExistCouponInReservationException extends RuntimeException {
-	public NotExistCouponInReservationException(String message) {
-		super(message);
-	}
-}

--- a/src/main/java/com/health/healther/exception/coupon/NotUsedCouponException.java
+++ b/src/main/java/com/health/healther/exception/coupon/NotUsedCouponException.java
@@ -1,0 +1,7 @@
+package com.health.healther.exception.coupon;
+
+public class NotUsedCouponException extends RuntimeException {
+	public NotUsedCouponException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/health/healther/service/CouponService.java
+++ b/src/main/java/com/health/healther/service/CouponService.java
@@ -18,6 +18,7 @@ import com.health.healther.dto.coupon.CouponCreateRequestDto;
 import com.health.healther.dto.coupon.CouponReservationListResponseDto;
 import com.health.healther.dto.coupon.CouponUpdateRequestDto;
 import com.health.healther.exception.coupon.NotFoundCouponException;
+import com.health.healther.exception.coupon.NotUsedCouponException;
 import com.health.healther.exception.space.NotFoundSpaceException;
 
 import lombok.RequiredArgsConstructor;
@@ -96,6 +97,18 @@ public class CouponService {
 			.orElseThrow(() -> new NotFoundCouponException("쿠폰 정보를 찾을 수 없습니다."));
 
 		coupon.useCoupon(true);
+	}
+
+	@Transactional
+	public void cancelUseCoupon(Long couponId) {
+		Coupon coupon = couponRepository.findById(couponId)
+			.orElseThrow(() -> new NotFoundCouponException("쿠폰 정보를 찾을 수 없습니다."));
+
+		if (!coupon.isUsed()) {
+			throw new NotUsedCouponException("사용되지 않은 쿠폰입니다.");
+		}
+
+		coupon.useCoupon(false);
 	}
 
 }


### PR DESCRIPTION
## Issue

- #125 

## Description

- 예약 취소 과정 중 예약 당시 사용된 쿠폰도 취소되는 로직을 추가하였습니다

## Todo

- [x] 예약 시 Coupon의 isUsed를 `true`에서 `false`로 변환
- [x] 로직 진행 중 들어온 couponId 값의 isUsed가 혹시 `false`일 경우 예외 처리

## ETC

- ~~쿠폰 관련한 Exception은 제가 생성하는게 맞는 것 같아 `NotExistCouponInReservationException` 이라는 Exception 생성해두었습니다! reservationService에서 해당 Exception을 사용하지 않으실 예정이거나 리네임을 원하시면 언제든 comment 주세요!~~ 
해당 Exception 삭제하였습니다!
- 질문사항이나 수정사항이 있을시 comment 남겨주시면 감사하겠습니다 :-)
