### PR TITLE
[#137] 테이블 생성 시 테이블명 모두 대문자로 변경

### DIFF
--- a/src/main/java/com/health/healther/config/UpperCaseNamingStrategy.java
+++ b/src/main/java/com/health/healther/config/UpperCaseNamingStrategy.java
@@ -1,0 +1,12 @@
+package com.health.healther.config;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy;
+
+public class UpperCaseNamingStrategy extends SpringPhysicalNamingStrategy {
+	@Override
+	protected Identifier getIdentifier(String name, boolean quoted, JdbcEnvironment jdbcEnvironment) {
+		return new Identifier(name.toUpperCase(), quoted);
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,6 +10,8 @@ spring:
     open-in-view: true
     hibernate:
       ddl-auto: update
+      naming:
+        physical-strategy: com.health.healther.config.UpperCaseNamingStrategy
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,8 @@ spring:
     open-in-view: true
     hibernate:
       ddl-auto: update
+      naming:
+        physical-strategy: com.health.healther.config.UpperCaseNamingStrategy
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,8 @@ spring:
     open-in-view: true
     hibernate:
       ddl-auto: validate
+      naming:
+        physical-strategy: com.health.healther.config.UpperCaseNamingStrategy
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## Issue
- #137 

## Description
기존 테이블 생성시 전략을 걸어두지 않았고 그에따라 테이블이 모두 소문자로 작성되었습니다.
soft deleted를 사용하기위해 `@SQLDelete` 에 쿼리를 적어두었는데 해당 쿼리에는 대문자로 올라가있어
테이블 생성 전략을 대문자로 변경하였습니다

## Todo

## ETC