### PR TITLE
[#140] 로그인 후 expiredTime 응답값 변경

### DIFF
--- a/src/main/java/com/health/healther/dto/member/AccessTokenResponseDto.java
+++ b/src/main/java/com/health/healther/dto/member/AccessTokenResponseDto.java
@@ -14,5 +14,5 @@ import lombok.ToString;
 public class AccessTokenResponseDto {
 	private String accessToken;
 
-	private Long expiredTime;
+	private String expiredTime;
 }

--- a/src/main/java/com/health/healther/dto/member/MemberLoginResponseDto.java
+++ b/src/main/java/com/health/healther/dto/member/MemberLoginResponseDto.java
@@ -17,7 +17,7 @@ public class MemberLoginResponseDto {
 
 	private String accessToken;
 
-	private Long expiredTime;
+	private String expiredTime;
 
 	private String refreshToken;
 }

--- a/src/main/java/com/health/healther/service/AuthService.java
+++ b/src/main/java/com/health/healther/service/AuthService.java
@@ -1,5 +1,8 @@
 package com.health.healther.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,10 +46,11 @@ public class AuthService {
 			throw new InvalidTokenException("유효하지 않는 액세스 토큰입니다.");
 		}
 		Token newAccessToken = jwtTokenProvider.createAccessToken(id);
+		LocalDateTime expiredTime = LocalDateTime.now().plusSeconds(newAccessToken.getExpiredTime() / 1000);
 		return AccessTokenResponseDto
 			.builder()
 			.accessToken(newAccessToken.getValue())
-			.expiredTime(newAccessToken.getExpiredTime())
+			.expiredTime(expiredTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
 			.build();
 	}
 

--- a/src/main/java/com/health/healther/service/OauthService.java
+++ b/src/main/java/com/health/healther/service/OauthService.java
@@ -3,6 +3,8 @@ package com.health.healther.service;
 import static com.health.healther.constant.MemberStatus.*;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -83,11 +85,12 @@ public class OauthService {
 	private MemberLoginResponseDto getMemberLoginResponseDto(Member member) {
 		Token accessToken = jwtAuthenticationProvider.createAccessToken(String.valueOf(member.getId()));
 		Token refreshToken = jwtAuthenticationProvider.createRefreshToken();
+		LocalDateTime expiredTime = LocalDateTime.now().plusSeconds(accessToken.getExpiredTime() / 1000);
 		redisUtil.setDataExpire(String.valueOf(member.getId()), refreshToken.getValue(), refreshToken.getExpiredTime());
 		return MemberLoginResponseDto.builder()
 			.tokenType(BEARER_TYPE)
 			.accessToken(accessToken.getValue())
-			.expiredTime(accessToken.getExpiredTime())
+			.expiredTime(expiredTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
 			.refreshToken(refreshToken.getValue())
 			.build();
 	}


### PR DESCRIPTION
## Issue

- #140 

## Description
- front와 refreshToken 재발급 맞춰보던 중 expiredTime 값의 변경요청에 따라 리팩토링하였습니다.
- `milliseconds` -> `현재 시간 + milliSeconds` 의 String 형태로 반환 받게 됩니다.
ex) `3600000` -> `2023-01-29 22:28:44`

## ETC
- 궁금하신점 댓글 부탁드립니다.