### PR TITLE
[#167] 게시글 조회 관련 리팩토링

### DIFF
--- a/src/main/java/com/health/healther/controller/BoardController.java
+++ b/src/main/java/com/health/healther/controller/BoardController.java
@@ -93,9 +93,10 @@ public class BoardController {
 
     @GetMapping("/{boardId}/comment")
     public ResponseEntity<List<CommentListResponseDto>> getCommentList(
-            @RequestBody @Valid CommentListRequestDto request,
+            @RequestParam("page") int page,
+            @RequestParam("size") int size,
             @PathVariable("boardId") Long id
     ) {
-        return new ResponseEntity<>(boardService.getCommentList(id,request), HttpStatus.OK);
+        return new ResponseEntity<>(boardService.getCommentList(id,page,size), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/health/healther/controller/BoardController.java
+++ b/src/main/java/com/health/healther/controller/BoardController.java
@@ -29,9 +29,10 @@ public class BoardController {
 
     @GetMapping
     public ResponseEntity<List<GetBoardListResponseDto>> getBoardList(
-            @RequestBody @Valid GetBoardListRequestDto request
+            @RequestParam("page") int page,
+            @RequestParam("size") int size
     ) {
-        return new ResponseEntity<>(boardService.getBoardList(request), HttpStatus.OK);
+        return new ResponseEntity<>(boardService.getBoardList(page,size), HttpStatus.OK);
     }
 
     @GetMapping("/{boardId}")

--- a/src/main/java/com/health/healther/service/BoardService.java
+++ b/src/main/java/com/health/healther/service/BoardService.java
@@ -47,10 +47,10 @@ public class BoardService {
     }
     
     @Transactional(readOnly = true)
-    public List<GetBoardListResponseDto> getBoardList(GetBoardListRequestDto request) {
+    public List<GetBoardListResponseDto> getBoardList(int page, int size) {
       
         PageRequest pageRequest
-                = PageRequest.of(request.getPage(), request.getSize(), Sort.by("modifiedAt").descending());
+                = PageRequest.of(page, size, Sort.by("modifiedAt").descending());
 
         return boardRepository.findAll(pageRequest).stream()
                 .map(GetBoardListResponseDto :: from)

--- a/src/main/java/com/health/healther/service/BoardService.java
+++ b/src/main/java/com/health/healther/service/BoardService.java
@@ -156,13 +156,13 @@ public class BoardService {
     }
 
     @Transactional(readOnly = true)
-    public List<CommentListResponseDto> getCommentList(Long id, CommentListRequestDto request) {
+    public List<CommentListResponseDto> getCommentList(Long id, int page, int size) {
 
         Board board = boardRepository.findById(id)
                                      .orElseThrow(() -> new NotFoundBoardException("게시판 정보를 찾을 수 없습니다."));
                                      
         PageRequest pageRequest
-                = PageRequest.of(request.getPage(), request.getSize(), Sort.by("modifiedAt").descending());
+                = PageRequest.of(page, size, Sort.by("modifiedAt").descending());
 
         return commentRepository.findByBoard(board,pageRequest).stream()
                 .map(CommentListResponseDto::from)


### PR DESCRIPTION
## Issue

- #167 

## Description
- 조회 관련 API 에서 page,size 를 프론트로부터 전달받을 때 기존 `body` 로 전달 받는 방식에서 `쿼리 스트링`으로 전달 받는 방식으로 변경하였습니다.
- 기존 Request 관련 DTO는 아직 merge 전인 다른 PR 들이 있어 삭제하지 않았습니다. 어느정도 PR이 merge 될 시 삭제하는 작업을 따로 진행하겠습니다.
## Todo

## ETC
- 적극적인 피드백 부탁드립니다.