### PR TITLE
[#179] CORS 설정 내 'OPTIONS' 메서드 허가

### DIFF
--- a/src/main/java/com/health/healther/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/health/healther/config/JwtAuthenticationFilter.java
@@ -32,6 +32,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
+		if (request.getMethod().equals("OPTIONS")) {
+			return;
+		}
 		try {
 			String token = resolveTokenFromRequest(request);
 			if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {

--- a/src/main/java/com/health/healther/config/WebMvcConfig.java
+++ b/src/main/java/com/health/healther/config/WebMvcConfig.java
@@ -9,11 +9,10 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
-
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedMethods("GET", "POST", "PUT", "DELETE")
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 			.allowedHeaders("*")
 			.allowedOriginPatterns("*")
 			.exposedHeaders("*")


### PR DESCRIPTION
## Issue

- #179 

## Description
- front 작업 중 게시글 추천/추천 취소 로직에서 CORS 에러가 발생하였습니다.
- 확실한 원인일지는 모르겠으나 Preflight Request로 생각하여 CORS내 "OPTIONS" 메서드를 허가하였습니다.
- 이에 따라 JWT filter에서도 Preflight Request 시 메서드를 종료하게끔 수정하였습니다.

## ETC
- 궁금하신점 댓글로 남겨주세요